### PR TITLE
I've updated the .NET SDK and C# library versions for you.

### DIFF
--- a/example/RResult.Api.Test/RResult.Api.Test.csproj
+++ b/example/RResult.Api.Test/RResult.Api.Test.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" >
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" >
+    <PackageReference Include="coverlet.collector" Version="6.0.4" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/example/RResult.Api.Test/global.json
+++ b/example/RResult.Api.Test/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "8.0.409",
     "rollForward": "latestFeature"
   }
 }

--- a/example/RResult.Api/RResult.Api.csproj
+++ b/example/RResult.Api/RResult.Api.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     <ProjectReference Include="..\..\src\RResult\RResult.csproj" />
   </ItemGroup>
 </Project>

--- a/example/RResult.Api/global.json
+++ b/example/RResult.Api/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "8.0.409",
     "rollForward": "latestFeature"
   }
 }

--- a/src/RResult.Test/RResult.Test.csproj
+++ b/src/RResult.Test/RResult.Test.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "8.0.409",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
I changed the .NET SDK version specified in your global.json files to 8.0.409.

I also updated the following package dependencies to their latest stable versions compatible with .NET 8:

- In example/RResult.Api/RResult.Api.csproj:
  - Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore to 8.0.16
  - Microsoft.AspNetCore.OpenApi to 8.0.16
  - Microsoft.EntityFrameworkCore.InMemory to 8.0.16
  - Swashbuckle.AspNetCore to 8.1.1

- In example/RResult.Api.Test/RResult.Api.Test.csproj:
  - Microsoft.EntityFrameworkCore.InMemory to 8.0.16
  - Microsoft.NET.Test.Sdk to 17.14.0
  - xunit to 2.9.3
  - xunit.runner.visualstudio to 3.1.0
  - coverlet.collector to 6.0.4

- In src/RResult.Test/RResult.Test.csproj:
  - Microsoft.NET.Test.Sdk to 17.14.0
  - MSTest.TestAdapter to 3.9.0
  - MSTest.TestFramework to 3.9.0
  - coverlet.collector to 6.0.4

All your projects were successfully built and all tests passed after these updates.